### PR TITLE
Detect Java Maven project and clean target folder

### DIFF
--- a/src/discover_projects/detect_cleanable_project.rs
+++ b/src/discover_projects/detect_cleanable_project.rs
@@ -48,6 +48,7 @@ pub fn detect_cleanable_project(path: &Path) -> Option<Project> {
 	// Java projects
 	if exists_in_path(path, "pom.xml") {
 		is_project = true;
+		project.add_cleanable_dir_if_exists("target");
 		project.add_cleanable_dir_if_exists(".gradle");
 		project.add_cleanable_dir_if_exists("build");
 	}


### PR DESCRIPTION
Actually for Java only Gradle projects are detected, Maven is probably more widely used than Gradle (except may be for Android projects) and for that, target folder containing all compiled classes must be cleaned by sweep (like gradle, these java projects have a pom.xml file)