### PR TITLE
Add build+dist to Node project cleanup

### DIFF
--- a/src/discover_projects/detect_cleanable_project.rs
+++ b/src/discover_projects/detect_cleanable_project.rs
@@ -131,8 +131,8 @@ mod test {
 
 		test_project!(
 			files: ["package.json"],
-			dirs: ["src", "node_modules", ".cache", ".idea"],
-			cleanable: ["node_modules", ".cache"]
+			dirs: ["src", "node_modules", ".cache", ".idea", "build", "dist"],
+			cleanable: ["node_modules", ".cache", "build", "dist"]
 		);
 	}
 

--- a/src/discover_projects/detect_cleanable_project.rs
+++ b/src/discover_projects/detect_cleanable_project.rs
@@ -43,6 +43,8 @@ pub fn detect_cleanable_project(path: &Path) -> Option<Project> {
 		is_project = true;
 		project.add_cleanable_dir_if_exists("node_modules");
 		project.add_cleanable_dir_if_exists(".cache");
+		project.add_cleanable_dir_if_exists("build");
+		project.add_cleanable_dir_if_exists("dist");
 	}
 
 	// Java projects


### PR DESCRIPTION
This adds `build` and `dist` to Node projects. These folders are often used by TypeScript and/or webpack. Running on my own local machine it cleaned several projects.

**Tests added.**